### PR TITLE
Align mirror site quiz handling with desk tidy

### DIFF
--- a/Yr-10-Mirror-main/index.html
+++ b/Yr-10-Mirror-main/index.html
@@ -3017,6 +3017,28 @@
 </fieldset>
 <span class="quiz-msg"></span></form></article>
 </section>
+<!-- Popups for quiz submission (copied from Desk Tidy project) -->
+<div id="resultPopup" class="popup-overlay" role="dialog" aria-modal="true">
+  <div class="popup-box">
+    <button class="close-popup" aria-label="Close">&times;</button>
+    <h3>Results Submitted</h3>
+    <p>You can now visit Google Classroom to record your work.</p>
+    <a id="popupClassroomLink" href="https://classroom.google.com/c/NzQ5MDQxMzk4MjAz" target="_blank">Open Google Classroom</a>
+  </div>
+</div>
+<div id="submittedPopup" class="popup-overlay" role="dialog" aria-modal="true">
+  <div class="popup-box">
+    <p>Your results have been submitted.</p>
+    <button id="submittedOkBtn">OK</button>
+  </div>
+</div>
+<div id="namePopup" class="popup-overlay" role="dialog" aria-modal="true">
+  <div class="popup-box">
+    <label for="studentName"><b>Please enter your name:</b></label><br/>
+    <input type="text" id="studentName" style="margin-top:10px; padding:8px; width:95%;" />
+    <button id="submitNameBtn" style="margin-top:10px;">Submit</button>
+  </div>
+</div>
 <!--        FOOTER SECTION
        Contains the footer content and back-to-top link.
   ============================================================ -->

--- a/Yr-10-Mirror-main/script.js
+++ b/Yr-10-Mirror-main/script.js
@@ -1,141 +1,239 @@
-function speakText(btn){
-  const text = btn.parentElement.textContent.replace("🔊", "").trim();
-  const utterance = new SpeechSynthesisUtterance(text);
-  speechSynthesis.speak(utterance);
+const SCRIPT_URL = "https://script.google.com/macros/s/AKfycbw1EWli5lAQsObQA47T-OpwAjkXAFSgLcqqf7nCN5zjoEoNMPuA4FmsGSHHN9tKhJhj-w/exec";
+const CLASSROOM_LINK = "https://classroom.google.com/c/NzQ5MDQxMzk4MjAz";
+
+const synth = window.speechSynthesis;
+let voices = [];
+synth.onvoiceschanged = () => { voices = synth.getVoices(); };
+
+function speakText(btn) {
+  let text = '';
+  if (btn.dataset.text) {
+    text = btn.dataset.text;
+  } else {
+    const p = btn.closest('p');
+    if (p) {
+      text = Array.from(p.childNodes)
+        .filter(n => n.nodeType === Node.TEXT_NODE)
+        .map(n => n.textContent.trim())
+        .join(' ');
+    } else {
+      const lbl = btn.closest('label');
+      text = Array.from(lbl.childNodes)
+        .filter(n => n.nodeType === Node.TEXT_NODE)
+        .map(n => n.textContent.trim())
+        .filter(t => t.length)
+        .join(' ');
+    }
+  }
+  if (!voices.length) voices = synth.getVoices();
+  const utt = new SpeechSynthesisUtterance(text);
+  utt.voice = voices.find(v => v.name === 'Google UK English Female') ||
+              voices.find(v => /Natural/.test(v.name)) ||
+              voices[0];
+  synth.speak(utt);
 }
 
-// Backend configuration
-const APP_URL = 'https://script.google.com/macros/s/AKfycbya0EHlfInCNU8toTn0nNeHxJSIesb9V7ms4t1ZC7dflc9AJuraEHg4tS897fNNBsRm/exec';
-// Replace with the token configured in your Apps Script, or leave blank
-const APP_TOKEN = 'OPTIONAL_SECRET_TOKEN';
+function showResultPopup(url) {
+  const overlay = document.getElementById('resultPopup');
+  const link = document.getElementById('popupClassroomLink');
+  if (link) link.href = url || '#';
+  if (overlay) overlay.classList.add('active');
+}
 
-// Simple custom modal utilities to avoid browser alert/prompt headings
-function showAlert(message) {
-  return new Promise((resolve) => {
-    const overlay = document.createElement('div');
-    overlay.className = 'modal-overlay';
-    overlay.innerHTML = `
-      <div class="modal-content">
-        <p>${message}</p>
-        <button id="modal-ok">OK</button>
-      </div>`;
-    document.body.appendChild(overlay);
-    overlay.querySelector('#modal-ok').addEventListener('click', () => {
-      document.body.removeChild(overlay);
-      resolve();
+function showSubmittedPopup(url) {
+  const overlay = document.getElementById('submittedPopup');
+  const btn = document.getElementById('submittedOkBtn');
+  if (!overlay || !btn) { showResultPopup(url); return; }
+  overlay.classList.add('active');
+  btn.onclick = () => {
+    overlay.classList.remove('active');
+    showResultPopup(url);
+  };
+}
+
+function askForName() {
+  return new Promise(resolve => {
+    const overlay = document.getElementById('namePopup');
+    const input = document.getElementById('studentName');
+    const btn = document.getElementById('submitNameBtn');
+    if (!overlay || !input || !btn) { resolve(''); return; }
+    overlay.classList.add('active');
+    btn.onclick = () => {
+      const name = input.value.trim();
+      if (!name) return;
+      overlay.classList.remove('active');
+      resolve(name);
+    };
+  });
+}
+
+function shuffleQuizAnswers() {
+  document.querySelectorAll('form.quiz li').forEach(li => {
+    const labels = Array.from(li.querySelectorAll('label'));
+    if (labels.length <= 1) return;
+    li.querySelectorAll('br').forEach(br => br.remove());
+    labels.forEach(l => l.remove());
+    for (let i = labels.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [labels[i], labels[j]] = [labels[j], labels[i]];
+    }
+    labels.forEach((label, idx) => {
+      li.appendChild(label);
+      if (idx < labels.length - 1) li.appendChild(document.createElement('br'));
     });
   });
 }
 
-function showPrompt(message) {
-  return new Promise((resolve) => {
-    const overlay = document.createElement('div');
-    overlay.className = 'modal-overlay';
-    overlay.innerHTML = `
-      <div class="modal-content">
-        <p>${message}</p>
-        <input type="text" id="modal-input" />
-        <div class="modal-buttons">
-          <button id="modal-submit">Submit</button>
-          <button id="modal-cancel">Cancel</button>
-        </div>
-      </div>`;
-    document.body.appendChild(overlay);
-    const remove = () => document.body.removeChild(overlay);
-    overlay.querySelector('#modal-submit').addEventListener('click', () => {
-      const value = overlay.querySelector('#modal-input').value;
-      remove();
-      resolve(value);
+function initQuizFeatures() {
+  shuffleQuizAnswers();
+  const closeBtn = document.querySelector('#resultPopup .close-popup');
+  if (closeBtn) {
+    closeBtn.addEventListener('click', () => {
+      document.getElementById('resultPopup').classList.remove('active');
     });
-    overlay.querySelector('#modal-cancel').addEventListener('click', () => {
-      remove();
-      resolve(null);
-    });
+  }
+  document.querySelectorAll('form.quiz li > p button').forEach(btn => {
+    if (!btn.hasAttribute('aria-label')) {
+      btn.setAttribute('aria-label', 'Read question aloud');
+    }
+  });
+  document.querySelectorAll('form.quiz label').forEach(label => {
+    if (!label.querySelector('button')) {
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.textContent = '🔊';
+      const answerText = label.textContent.trim();
+      btn.setAttribute('aria-label', 'Read answer ' + answerText);
+      btn.addEventListener('click', e => { e.preventDefault(); speakText(btn); });
+      label.appendChild(document.createTextNode(' '));
+      label.appendChild(btn);
+    }
   });
 }
 
-    // Listen for clicks on nav links to toggle active sections
-    const navLinks = document.querySelectorAll('.nav-link');
-    const sections = document.querySelectorAll('.content-section');
-    navLinks.forEach(link => {
-      link.addEventListener('click', (e) => {
-        e.preventDefault();
-        // Remove active class from all nav links and sections
-        navLinks.forEach(nav => nav.classList.remove('active'));
-        sections.forEach(sec => sec.classList.remove('active'));
-        // Add active class to clicked link and corresponding section
-        link.classList.add('active');
-        const targetID = link.getAttribute('data-section');
-        document.getElementById(targetID).classList.add('active');
-        // Scroll to top of the section for better user experience
-        document.getElementById(targetID).scrollIntoView({ behavior: 'smooth' });
-      });
-    });
+function initPage() {
+  const navLinks = document.querySelectorAll('.nav-link');
+  const sections = document.querySelectorAll('.content-section');
 
-// Rewritten quiz submission logic
-async function submitQuiz(button, week, level) {
-  const studentName = await showPrompt('Please enter your full name:');
-  if (!studentName || studentName.trim() === '') {
-    await showAlert('You must enter your name to submit the quiz.');
-    return;
+  function setActiveSection() {
+    let targetID = window.location.hash.substring(1) || 'program';
+    if (!document.getElementById(targetID)) {
+      targetID = 'program';
+    }
+
+    navLinks.forEach(nav => {
+      nav.classList.remove('active');
+      if (nav.getAttribute('data-section') === targetID) {
+        nav.classList.add('active');
+      }
+    });
+    sections.forEach(sec => {
+      sec.classList.remove('active');
+      if (sec.id === targetID) {
+        sec.classList.add('active');
+      }
+    });
   }
 
-  const quiz = button.closest('.quiz');
-  const questions = quiz.querySelectorAll('li');
-  let correct = 0;
+  setActiveSection();
+
+  navLinks.forEach(link => {
+    link.addEventListener('click', e => {
+      e.preventDefault();
+      const targetID = link.getAttribute('data-section');
+      window.location.hash = targetID;
+
+      navLinks.forEach(nav => nav.classList.remove('active'));
+      sections.forEach(sec => sec.classList.remove('active'));
+
+      link.classList.add('active');
+      const targetSection = document.getElementById(targetID);
+      if (targetSection) {
+        targetSection.classList.add('active');
+        targetSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }
+    });
+  });
+
+  window.addEventListener('hashchange', setActiveSection);
+}
+
+function submitQuiz(btn, week, level) {
+  const form = btn.closest('form');
+  const fieldset = form.querySelector('fieldset');
+  let correct = 0, total = 0;
+  const results = [];
   const textResponses = [];
 
-  questions.forEach(q => {
-    const textarea = q.querySelector('textarea');
-    const labels = q.querySelectorAll('label');
-    labels.forEach(l => l.removeAttribute('data-result'));
-
+  fieldset.querySelectorAll('li').forEach(li => {
+    const textarea = li.querySelector('textarea');
     if (textarea) {
-      textResponses.push({ answer: textarea.value });
+      textResponses.push({
+        question: li.querySelector('p')?.textContent || '',
+        answer: textarea.value.trim()
+      });
       return;
     }
 
-    const selected = q.querySelector('input[type="radio"]:checked');
-    if (selected) {
-      if (selected.hasAttribute('data-correct')) {
-        correct++;
-        selected.parentElement.setAttribute('data-result', 'right');
-      } else {
-        selected.parentElement.setAttribute('data-result', 'wrong');
+    const radios = li.querySelectorAll('input[type=radio]');
+    let userCorrect = false;
+    radios.forEach(radio => {
+      if (radio.checked && radio.getAttribute('data-correct') === 'true') {
+        userCorrect = true;
       }
-    }
+      radio.parentElement.removeAttribute('data-result');
+    });
+    total += 1;
+    radios.forEach(radio => {
+      if (radio.checked) {
+        radio.parentElement.setAttribute('data-result', userCorrect ? 'right' : 'wrong');
+      }
+    });
+    if (userCorrect) correct += 1;
+    results.push({
+      question: li.querySelector('p')?.textContent || '',
+      answer: Array.from(radios).find(r => r.checked)?.value || ''
+    });
   });
 
-  const scoredQuestions = questions.length - textResponses.length;
-  const scoreText = `${correct}/${scoredQuestions}`;
-
-  const prefixes = { main: 'M', support: 'S', advanced: 'A' };
-  const prefix = prefixes[level.toLowerCase()] || 'M';
-  const weekNumMatch = week.match(/\d+/);
-  const weekNum = weekNumMatch ? weekNumMatch[0] : '';
-  const quizNumber = prefix + weekNum;
-
-  const payload = { studentName, quizNumber };
-
-  if (level.toLowerCase() === 'advanced' && textResponses.length) {
-    payload.responses = textResponses;
+  let msg;
+  if (textResponses.length) {
+    msg = 'Responses submitted. Your teacher will review them.';
   } else {
-    payload.score = scoreText;
+    msg = `You got ${correct} out of ${total} correct.`;
   }
+  form.querySelector('.quiz-msg').textContent = msg;
 
-  if (APP_TOKEN) {
-    payload.token = APP_TOKEN;
-  }
-
-  try {
-    await fetch(APP_URL, {
+  askForName().then(name => {
+    const prefixes = { main: 'M', support: 'S', advanced: 'A' };
+    const prefix = prefixes[level?.toLowerCase()] || 'M';
+    const weekNumMatch = week.match(/\d+/);
+    const weekNum = weekNumMatch ? parseInt(weekNumMatch[0], 10) : 0;
+    const quizNumber = prefix + weekNum;
+    const payload = {
+      quizType: week,
+      quizNumber,
+      studentName: name,
+      timestamp: new Date().toISOString()
+    };
+    if (textResponses.length) {
+      payload.responses = textResponses;
+    } else {
+      payload.quiz = results;
+      payload.score = `${correct}/${total}`;
+    }
+    fetch(SCRIPT_URL, {
       method: 'POST',
+      mode: 'no-cors',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload)
+    }).then(() => {
+      showSubmittedPopup(CLASSROOM_LINK);
     });
-    quiz.querySelector('.quiz-msg').textContent = `You got ${scoreText} correct.`;
-    await showAlert('Quiz responses submitted successfully!');
-  } catch (err) {
-    await showAlert('There was an error submitting the quiz.');
-  }
+  });
 }
+
+document.addEventListener('DOMContentLoaded', () => {
+  initPage();
+  initQuizFeatures();
+});

--- a/Yr-10-Mirror-main/style.css
+++ b/Yr-10-Mirror-main/style.css
@@ -200,6 +200,65 @@
     .modal-buttons {
       margin-top: 15px;
     }
-    .modal-buttons button {
+.modal-buttons button {
       margin: 0 5px;
     }
+
+/* Popup box styles copied from Desk Tidy project */
+.popup-overlay {
+  display: none;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0,0,0,0.5);
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+.popup-overlay.active {
+  display: flex;
+}
+.popup-box {
+  background: #fff;
+  padding: 20px;
+  border-radius: 5px;
+  max-width: 400px;
+  width: 90%;
+  text-align: center;
+  position: relative;
+  box-shadow: 0 2px 5px rgba(0,0,0,0.3);
+}
+.popup-box a {
+  display: inline-block;
+  margin-top: 10px;
+  background: #007bff;
+  color: #fff;
+  padding: 10px 15px;
+  border-radius: 4px;
+  font-weight: bold;
+}
+.popup-box button:not(.close-popup) {
+  display: inline-block;
+  margin-top: 10px;
+  background: #007bff;
+  color: #fff;
+  padding: 10px 15px;
+  border: none;
+  border-radius: 4px;
+  font-weight: bold;
+  cursor: pointer;
+}
+.popup-box button:not(.close-popup):hover {
+  background: #0056b3;
+}
+.popup-box button.close-popup {
+  background: none;
+  border: none;
+  position: absolute;
+  top: 5px;
+  right: 10px;
+  font-size: 1.2em;
+  cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- copy Desk Tidy popup styles to the mirror site
- add result/name popups to mirror `index.html`
- replace mirror `script.js` with logic from Desk Tidy so quiz data posts to Google sheets

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6876f2dbe5248326b2ba80d2b026d9bd